### PR TITLE
[FGR-3555] Change cancel logic to allow cancel to occur

### DIFF
--- a/app/models/spree/gateway/stripe_terminal_gateway.rb
+++ b/app/models/spree/gateway/stripe_terminal_gateway.rb
@@ -35,17 +35,17 @@ module Spree
     end
 
     def cancel(response_code)
-      _payment = Spree::Payment.valid.where(
+      payment = Spree::Payment.valid.where(
         response_code: response_code,
         source_type:   payment_source_class.to_s
       ).first
 
-      return if _payment.nil?
+      return if payment.nil?
 
-      if _payment.pending?
-        _payment.void_transaction!
-      elsif _payment.completed? && _payment.can_credit?
-        provider.refund(_payment.credit_allowed.to_money.cents, response_code)
+      if payment.pending?
+        payment.void_transaction!
+      elsif payment.completed? && payment.can_credit?
+        provider.refund(payment.credit_allowed.to_money.cents, response_code)
       end
     end
 


### PR DESCRIPTION
Previously it would try and void the transaction but Spree doesn't allow that so we process as refund instead